### PR TITLE
Make generated XML compatible with JUnit XSD

### DIFF
--- a/doxygen_junit.py
+++ b/doxygen_junit.py
@@ -130,7 +130,10 @@ def generate_test_suite(errors_by_filename  # type: Dict[str, Set[DoxygenError]]
         test_suite.attrib['tests'] = str(len(errors_by_filename))
         for filename, errors in errors_by_filename.items():
             for error in errors:
-                test_case = ElementTree.SubElement(test_suite, 'testcase', name=filename, file=filename, line=str(error.line))
+                test_case = ElementTree.SubElement(test_suite, 'testcase',
+                                                   name=filename,
+                                                   file=filename,
+                                                   line=str(error.line))
                 ElementTree.SubElement(test_case, 'error',
                                        message='{}: {}'.format(error.line, error.message))
 

--- a/doxygen_junit.py
+++ b/doxygen_junit.py
@@ -129,9 +129,9 @@ def generate_test_suite(errors_by_filename  # type: Dict[str, Set[DoxygenError]]
         test_suite.attrib['errors'] = str(len(errors_by_filename))
         test_suite.attrib['tests'] = str(len(errors_by_filename))
         for filename, errors in errors_by_filename.items():
-            test_case = ElementTree.SubElement(test_suite, 'testcase', name=filename)
             for error in errors:
-                ElementTree.SubElement(test_case, 'error', file=filename, line=str(error.line),
+                test_case = ElementTree.SubElement(test_suite, 'testcase', name=filename, file=filename, line=str(error.line))
+                ElementTree.SubElement(test_case, 'error',
                                        message='{}: {}'.format(error.line, error.message))
 
     return ElementTree.ElementTree(test_suite)

--- a/test.py
+++ b/test.py
@@ -98,10 +98,10 @@ class GenerateTestSuiteTestCase(unittest.TestCase):
 
         test_case_element = root.find('testcase')
         self.assertEqual(test_case_element.get('name'), 'file_name')
+        self.assertEqual(test_case_element.get('file'), 'file_name')
+        self.assertEqual(test_case_element.get('line'), str(40))
 
         error_element = test_case_element.find('error')
-        self.assertEqual(error_element.get('file'), 'file_name')
-        self.assertEqual(error_element.get('line'), str(40))
         self.assertEqual(error_element.get('message'), '40: Compound Class is not documented.')
 
 


### PR DESCRIPTION
As defined e.g. in https://github.com/jenkinsci/xunit-plugin/blob/master/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd
an error element must only have "type" and "message" properties. Thus,
the "line" and "file" properties must be set for the testcase object.

Using a malformed XML file in the current JUnit Jenkins plugin leads
to an internal plugin error with the result of an empty error list.